### PR TITLE
fix(DO400-35): use Deployment in shopping-cart

### DIFF
--- a/shopping-cart/kubefiles/application-template.yml
+++ b/shopping-cart/kubefiles/application-template.yml
@@ -5,13 +5,14 @@ metadata:
   annotations:
     description: "Shopping Cart Template"
 objects:
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: shopping-cart-${APP_ENVIRONMENT}
     spec:
       selector:
-        app: shopping-cart-${APP_ENVIRONMENT}
+        matchLabels:
+          app: shopping-cart-${APP_ENVIRONMENT}
       replicas: 1
       template:
         metadata:
@@ -25,7 +26,7 @@ objects:
               ports:
                 - containerPort: 8080
       strategy:
-        type: Rolling
+        type: RollingUpdate
   - kind: Service
     apiVersion: v1
     metadata:


### PR DESCRIPTION
Change the `application-template.yaml` file to use a Deployment instead of the deprecated DeploymentConfig.

This change affects:
- ch06s03 GE: Deploying Applications to Various Environments

