### PR TITLE
fix(DO400-35): use Deployment in shopping cart security and Trivy check fix

### DIFF
--- a/shopping-cart/kubefiles/image-builder-template.yml
+++ b/shopping-cart/kubefiles/image-builder-template.yml
@@ -71,8 +71,8 @@ objects:
             name: openjdk-11:1.3-3
         type: Source
       triggers: []
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: ${APP_NAME}
@@ -82,13 +82,14 @@ objects:
     spec:
       replicas: 1
       selector:
-        deploymentconfig: ${APP_NAME}
+        matchLabels:
+          app: ${APP_NAME}
       strategy:
         resources: {}
       template:
         metadata:
           labels:
-            deploymentconfig: ${APP_NAME}
+            app: ${APP_NAME}
         spec:
           containers:
             - image: image-registry.openshift-image-registry.svc:5000/${PROJECT_NAME}/${APP_NAME}:latest
@@ -127,7 +128,7 @@ objects:
           protocol: TCP
           targetPort: 8778
       selector:
-        deploymentconfig: ${APP_NAME}
+        app: ${APP_NAME}
   - kind: Route
     apiVersion: route.openshift.io/v1
     metadata:

--- a/shopping-cart/kubefiles/security-scan-template.yml
+++ b/shopping-cart/kubefiles/security-scan-template.yml
@@ -24,7 +24,8 @@ objects:
                 - >-
                   cd /tmp &&
                   curl -sL https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_RELEASE}/trivy_${TRIVY_RELEASE}_Linux-64bit.tar.gz -o - | tar -zxf - &&
-                  ./trivy fs --severity HIGH,CRITICAL --no-progress --ignore-unfixed /
+                  { ./trivy fs --severity HIGH,CRITICAL --no-progress --ignore-unfixed / | grep ${CVE_CODE} ;
+                  ./trivy fs --severity HIGH,CRITICAL --no-progress --ignore-unfixed / | grep -qvz ${CVE_CODE} ; }
           restartPolicy: Never
 
 parameters:
@@ -39,3 +40,7 @@ parameters:
     description: "Trivy Release Version"
     required: false
     value: "0.14.0"
+  - name: CVE_CODE
+    description: "CVE Code"
+    required: false
+    value: "CVE-2020-14583"

--- a/shopping-cart/kubefiles/security-scan-template.yml
+++ b/shopping-cart/kubefiles/security-scan-template.yml
@@ -24,7 +24,7 @@ objects:
                 - >-
                   cd /tmp &&
                   curl -sL https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_RELEASE}/trivy_${TRIVY_RELEASE}_Linux-64bit.tar.gz -o - | tar -zxf - &&
-                  ./trivy fs --exit-code 1 --severity HIGH,CRITICAL --no-progress --ignore-unfixed /
+                  ./trivy fs --severity HIGH,CRITICAL --no-progress --ignore-unfixed /
           restartPolicy: Never
 
 parameters:

--- a/tools/grep-job-log.sh
+++ b/tools/grep-job-log.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+oc wait --for=condition=complete \
+  --timeout=60s job ${1} -n ${2}
+
+oc logs --selector=job-name=${1} -n ${2} --tail=-1
+
+echo "Check for '${3}'"
+
+oc logs --selector=job-name=${1} -n ${2} --tail=-1 | grep "${3}"


### PR DESCRIPTION
Change the `image-builder-template.yaml` file to use a Deployment instead of the deprecated DeploymentConfig.

This also changes the `security-scan-template.yml` file, due to a bug in the security scan step

This change affects:
- ch07s04 ge

We should not merge this until the new course release